### PR TITLE
Misc cleanup

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library( # Sets the name of the library.
         helper.cpp
         file_loader.cpp
         shader.cpp
+        simple_framebuffer.cpp
         framebuffer.cpp
         data_texture_pair.cpp
         )

--- a/app/src/main/cpp/data_texture_pair.cpp
+++ b/app/src/main/cpp/data_texture_pair.cpp
@@ -1,5 +1,5 @@
 //
-// Created by kirde on 2020-03-29.
+// Created by kirderf1 on 2020-03-29.
 //
 
 #include "data_texture_pair.h"

--- a/app/src/main/cpp/data_texture_pair.h
+++ b/app/src/main/cpp/data_texture_pair.h
@@ -1,5 +1,5 @@
 //
-// Created by kirde on 2020-03-29.
+// Created by kirderf1 on 2020-03-29.
 //
 
 #ifndef DATX02_20_21_DATA_TEXTURE_PAIR_H

--- a/app/src/main/cpp/framebuffer.cpp
+++ b/app/src/main/cpp/framebuffer.cpp
@@ -9,20 +9,14 @@
 #define ALOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
 #define LOGE(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
 
-void Framebuffer::create(int width, int height, bool simple) {
-    this->simple = simple;
+void Framebuffer::create(int width, int height) {
     this->width = width;
     this->height = height;
 
     // framebuffer configuration
     // -------------------------
-    glGenFramebuffers(1, &FBO);
-    bind();
-
-    if(simple){
-        unbind();
-        return;
-    }
+    FBO.init();
+    FBO.bind();
 
     // create a color attachment texture
     glGenTextures(1, &colorTextureTarget);
@@ -51,11 +45,17 @@ void Framebuffer::create(int width, int height, bool simple) {
 
 }
 
+void Framebuffer::clear() {
+    FBO.clear();
+    glDeleteTextures(1, &colorTextureTarget);
+    colorTextureTarget = 0;
+    glDeleteRenderbuffers(1, &RBO);
+    RBO = 0;
+}
+
 void Framebuffer::resize(int width, int height){
     this->width = width;
     this->height = height;
-    if(simple)
-        return;
     bind();
     // Allocate a texture
     glBindTexture(GL_TEXTURE_2D, colorTextureTarget);
@@ -72,9 +72,9 @@ GLuint Framebuffer::texture(){
 }
 
 void Framebuffer::bind() {
-    glBindFramebuffer(GL_FRAMEBUFFER, FBO);
+    FBO.bind();
 }
 
 void Framebuffer::unbind() {
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    FBO.unbind();
 }

--- a/app/src/main/cpp/framebuffer.h
+++ b/app/src/main/cpp/framebuffer.h
@@ -8,13 +8,18 @@
 #include <jni.h>
 #include <gles3/gl31.h>
 
+#include "simple_framebuffer.h"
+
 class Framebuffer {
     int width, height;
-    GLuint FBO, RBO;
+
+    SimpleFramebuffer FBO;
+    GLuint RBO;
     GLuint colorTextureTarget;
-    bool simple;
 public:
-    void create(int width, int height, bool simple=false);
+    void create(int width, int height);
+
+    void clear();
 
     void resize(int width, int height);
 

--- a/app/src/main/cpp/simple_framebuffer.cpp
+++ b/app/src/main/cpp/simple_framebuffer.cpp
@@ -1,0 +1,22 @@
+//
+// Created by kirderf1 on 2020-04-03.
+//
+
+#include "simple_framebuffer.h"
+
+void SimpleFramebuffer::init() {
+    glGenFramebuffers(1, &FBO);
+}
+
+void SimpleFramebuffer::clear() {
+    glDeleteFramebuffers(1, &FBO);
+    FBO = 0;
+}
+
+void SimpleFramebuffer::bind() {
+    glBindFramebuffer(GL_FRAMEBUFFER, FBO);
+}
+
+void SimpleFramebuffer::unbind() {
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}

--- a/app/src/main/cpp/simple_framebuffer.h
+++ b/app/src/main/cpp/simple_framebuffer.h
@@ -1,0 +1,23 @@
+//
+// Created by kirderf1 on 2020-04-03.
+//
+
+#ifndef DATX02_20_21_SIMPLE_FRAMEBUFFER_H
+#define DATX02_20_21_SIMPLE_FRAMEBUFFER_H
+
+#include <gles3/gl31.h>
+
+class SimpleFramebuffer {
+    GLuint FBO;
+public:
+
+    void init();
+
+    void clear();
+
+    void bind();
+
+    void unbind();
+};
+
+#endif //DATX02_20_21_SIMPLE_FRAMEBUFFER_H

--- a/app/src/main/cpp/simulator.cpp
+++ b/app/src/main/cpp/simulator.cpp
@@ -13,9 +13,9 @@
 #define DURATION(a, b) (std::chrono::duration_cast<std::chrono::milliseconds>(a - b)).count() / 1000.0f;
 
 int Simulator::init(){
+    initSize(12, 48, 12);
     if (!slab.init())
         return 0;
-    resize(12, 48, 12);
     initData();
 
     start_time = NOW;
@@ -23,11 +23,11 @@ int Simulator::init(){
     return 1;
 }
 
-void Simulator::resize(int width, int height, int depth) {
+void Simulator::initSize(int width, int height, int depth) {
     grid_width = width + 2;
     grid_height = height + 2;
     grid_depth = depth + 2;
-    slab.resize(width, height, depth);
+    slab.initSize(width, height, depth);
 }
 
 void Simulator::update(){

--- a/app/src/main/cpp/simulator.h
+++ b/app/src/main/cpp/simulator.h
@@ -30,13 +30,13 @@ class Simulator{
 public:
     int init();
 
-    void resize(int width, int height, int depth);
-
     void update();
 
     void getData(GLuint& densityData, GLuint& temperatureData, int& width, int& height, int& depth);
 
 private:
+
+    void initSize(int width, int height, int depth);
 
     void initData();
 

--- a/app/src/main/cpp/slab_operation.cpp
+++ b/app/src/main/cpp/slab_operation.cpp
@@ -32,7 +32,9 @@ int SlabOperator::init() {
     glDisable(GL_DEPTH_TEST);
     glDisable(GL_CULL_FACE);
 
-    resize(12, 48, 12);
+    FBO = new SimpleFramebuffer();
+    FBO->init();
+
     initData();
 
     initQuad();
@@ -46,13 +48,10 @@ int SlabOperator::init() {
 
 }
 
-// todo resize is not really supported right now because we would need to resize textures too
-void SlabOperator::resize(int width, int height, int depth){
+void SlabOperator::initSize(int width, int height, int depth){
     grid_width = width + 2;
     grid_height = height + 2;
     grid_depth = depth + 2;
-    FBO = new Framebuffer();
-    FBO->create(grid_width, grid_height, true);
 }
 
 void SlabOperator::initData() {

--- a/app/src/main/cpp/slab_operation.cpp
+++ b/app/src/main/cpp/slab_operation.cpp
@@ -57,7 +57,7 @@ void SlabOperator::initSize(int width, int height, int depth){
 void SlabOperator::initData() {
     divergence = createScalarDataPair(grid_width, grid_height, grid_depth, (float*)nullptr);
 
-    gradient = createScalarDataPair(grid_width, grid_height, grid_depth, (float*)nullptr);
+    jacobi = createScalarDataPair(grid_width, grid_height, grid_depth, (float*)nullptr);
 }
 
 void SlabOperator::initLine() {
@@ -323,7 +323,7 @@ void SlabOperator::fulladvection(DataTexturePair* velocity, DataTexturePair* dat
 }
 void SlabOperator::projection(DataTexturePair* velocity){
     createDivergence(velocity);
-    jacobi(20);
+    jacobiIteration(20);
     subtractGradient(velocity);
 }
 
@@ -336,10 +336,10 @@ void SlabOperator::createDivergence(DataTexturePair* vectorData) {
     //setBoundary(divergence, 0);
 }
 
-void SlabOperator::jacobi(int iterationCount) {
+void SlabOperator::jacobiIteration(int iterationCount) {
 
     for(int depth = 0; depth < grid_depth; depth++){
-        glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, gradient->getDataTexture(), 0, depth);
+        glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, jacobi->getDataTexture(), 0, depth);
         glClear(GL_COLOR_BUFFER_BIT);
     }
 
@@ -347,8 +347,8 @@ void SlabOperator::jacobi(int iterationCount) {
     divergence->bindData(GL_TEXTURE1);
 
     for(int i = 0; i < iterationCount; i++) {
-        gradient->bindData(GL_TEXTURE0);
-        interiorOperation(jacobiShader, gradient);
+        jacobi->bindData(GL_TEXTURE0);
+        interiorOperation(jacobiShader, jacobi);
 
         //setBoundary(gradient, 0);
     }
@@ -356,7 +356,7 @@ void SlabOperator::jacobi(int iterationCount) {
 
 void SlabOperator::subtractGradient(DataTexturePair* velocity){
     gradientShader.use();
-    gradient->bindData(GL_TEXTURE0);
+    jacobi->bindData(GL_TEXTURE0);
     velocity->bindData(GL_TEXTURE1);
 
     interiorOperation(gradientShader, velocity);

--- a/app/src/main/cpp/slab_operation.h
+++ b/app/src/main/cpp/slab_operation.h
@@ -36,7 +36,7 @@ class SlabOperator{
     Shader boundaryShader;
 
     DataTexturePair* divergence;
-    DataTexturePair* gradient;
+    DataTexturePair* jacobi;
 
     Shader temperatureShader;
     Shader divergenceShader, jacobiShader, gradientShader;
@@ -84,7 +84,7 @@ private:
 
     // Performs a number of jacobi iterations of the divergence field into jacobi
     //example value: iterationCount = 20
-    void jacobi(int iterationCount);
+    void jacobiIteration(int iterationCount);
 
     // Calculates the divergence of the vector field
     void createDivergence(DataTexturePair* vectorData);

--- a/app/src/main/cpp/slab_operation.h
+++ b/app/src/main/cpp/slab_operation.h
@@ -9,14 +9,14 @@
 #include <gles3/gl31.h>
 
 #include "shader.h"
-#include "framebuffer.h"
+#include "simple_framebuffer.h"
 #include "data_texture_pair.h"
 
 class SlabOperator{
     int grid_width, grid_height, grid_depth;
 
     // Framebuffer
-    Framebuffer* FBO;
+    SimpleFramebuffer* FBO;
 
     // result // todo remove
     GLuint texcoordsBuffer;
@@ -46,7 +46,7 @@ class SlabOperator{
 public:
     int init();
 
-    void resize(int width, int height, int depth);
+    void initSize(int width, int height, int depth);
 
     // Called at the beginning of a series of operations to prepare opengl
     void prepare();


### PR DESCRIPTION
Renamed jacobi() to jacobiIteration() in order to:
Renamed gradient to jacobi because gradient wasn't actually a gradient, it was the result from jacobi iteration that we take the gradient of. (aka pressure)
Created a SimpleFramebuffer to use for simulation instead of Framebuffer, since we don't need the extra features of the Framebuffer and it's misleading that we need to provide it with the width/height + that it is resizeable
After a quick fix by Axel, slab_operator.resize() was called twice, both by slab_operator.init() and simulator.resize(). I fixed this and also renamed the functions to initSize() since the sizes aren't changeable at runtime.